### PR TITLE
adding starting art canvas

### DIFF
--- a/src/app/components/ArtBox.tsx
+++ b/src/app/components/ArtBox.tsx
@@ -1,0 +1,67 @@
+// components/ThreeScene.js
+
+import React, { useEffect, useRef } from 'react';
+import * as THREE from 'three';
+import gsap from 'gsap';
+
+const ArtBox = () => {
+    const sceneRef = useRef(null);
+    const draggableRef = useRef(null);
+
+    useEffect(() => {
+        const draggable = draggableRef.current;
+        let offset = { x: 0, y: 0 };
+        let isDragging = false;
+
+        // Function to handle mouse down event
+        const onMouseDown = (event) => {
+            isDragging = true;
+            const rect = draggable.getBoundingClientRect();
+            offset.x = event.clientX - rect.left;
+            offset.y = event.clientY - rect.top;
+        };
+
+        // Function to handle mouse up event
+        const onMouseUp = () => {
+            isDragging = false;
+        };
+
+        // Function to handle mouse move event
+        const onMouseMove = (event) => {
+            if (isDragging) {
+                const x = event.clientX - offset.x;
+                const y = event.clientY - offset.y;
+                gsap.to(draggable, { x, y, duration: 0.1, ease: 'power2.out' }); // Use ease for smoother animation
+            }
+        };
+
+        // Add event listeners
+        draggable.addEventListener('mousedown', onMouseDown);
+        document.addEventListener('mouseup', onMouseUp);
+        document.addEventListener('mousemove', onMouseMove);
+
+        // Initial position calculation
+        const initialX = (window.innerWidth - draggable.offsetWidth) / 2;
+        const initialY = (window.innerHeight - draggable.offsetHeight) / 2;
+
+        // Set initial position
+        gsap.set(draggable, { x: initialX, y: initialY });
+
+        // Cleanup event listeners
+        return () => {
+            draggable.removeEventListener('mousedown', onMouseDown);
+            document.removeEventListener('mouseup', onMouseUp);
+            document.removeEventListener('mousemove', onMouseMove);
+        };
+    }, []);
+
+    return (
+        <div ref={sceneRef} style={{ width: '100%', height: '100vh', position: 'relative' }}>
+            <div ref={draggableRef} style={{ position: 'absolute', width: '100px', height: '100px', backgroundColor: 'red' }} />
+        </div>
+    );
+};
+
+
+
+export default ArtBox;

--- a/src/app/pages/feed/page.tsx
+++ b/src/app/pages/feed/page.tsx
@@ -1,0 +1,5 @@
+const Feed = () => {
+    return <h1>this is feed</h1>
+}
+
+export default Feed

--- a/src/app/pages/newpost/page.tsx
+++ b/src/app/pages/newpost/page.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import ArtBox from "@/app/components/ArtBox"
+const NewPost = () => {
+    return (
+
+        <div className="max-w-sm p-6 bg-white border border-gray-200 rounded-lg shadow">
+
+            <a href="#">
+                <h5 className="mb-2 text-2xl font-semibold tracking-tight text-gray-900">Create new art</h5>
+            </a>
+            <div className="w-4">
+                <ArtBox />
+
+            </div>
+
+            <p className="mb-3 font-normal text-gray-500 dark:text-gray-400">need to add configs</p>
+            <button className="bg-white hover:bg-gray-100 text-gray-800 font-semibold py-2 px-4 border border-gray-400 rounded shadow">
+                Post
+            </button>
+
+        </div>)
+
+}
+
+export default NewPost


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit c0a90f1bd969c533b1d99dc76840d07febdb9fa3  | 
|--------|--------|

### Summary:
Added a draggable art canvas component and integrated it into the new post creation page, along with a placeholder feed page.

**Key points**:
- Added `src/app/components/ArtBox.tsx` to create a draggable art canvas using `THREE.js` and `gsap`.
- Implemented mouse event handlers (`onMouseDown`, `onMouseUp`, `onMouseMove`) in `ArtBox` for drag functionality.
- Integrated `ArtBox` into `src/app/pages/newpost/page.tsx` for new post creation.
- Added a placeholder feed page in `src/app/pages/feed/page.tsx`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->